### PR TITLE
fixed ironic compile error

### DIFF
--- a/src/nsuds.c
+++ b/src/nsuds.c
@@ -341,7 +341,7 @@ int getkey(void)
             return c;
       }
    }
-   //for compilers sake
+   /* for compilers sake */
    return c;
 }
 


### PR DESCRIPTION
replaced C++ style comment "//x" with C style comment "/\* x */" to prevent a compile error.

the very ironic error in question: 
"
nsuds.c: In function ‘getkey’:
nsuds.c:344:4: error: C++ style comments are not allowed in ISO C90
    //for compilers sake
    ^
"
